### PR TITLE
Make Entity attributes to be serde_json::Value.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -269,9 +269,6 @@ impl HassClient {
         });
         let response = self.gateway.command(states_req).await?;
 
-        // TODO - problem Entity atributes could be different, so this may be wrong
-        // have to make it Value, and based on entity_id deserialize differently ?
-        // or has to be handled by the user?
         match response {
             Response::Result(data) => match data.success {
                 true => {

--- a/src/types/entities.rs
+++ b/src/types/entities.rs
@@ -1,4 +1,5 @@
 use serde_derive::Deserialize;
+use serde_json::Value;
 
 /// This object represents the Home Assistant Entity
 ///
@@ -9,29 +10,8 @@ pub struct HassEntity {
     pub state: String,
     pub last_changed: String,
     pub last_updated: String,
-    pub attributes: HassEntityAttributeBase,
+    pub attributes: Value,
     pub context: Context,
-}
-
-///	This is part of HassEntity
-#[derive(Debug, Deserialize, PartialEq)]
-pub struct HassEntityAttributeBase {
-    #[serde(default)]
-    pub friendly_name: String,
-    #[serde(default)]
-    pub unit_of_measurement: String,
-    #[serde(default)]
-    pub icon: String,
-    #[serde(default)]
-    pub entity_picture: String,
-    #[serde(default)]
-    pub supported_features: u32,
-    #[serde(default)]
-    pub hidden: bool,
-    #[serde(default)]
-    pub assumed_state: bool,
-    #[serde(default)]
-    pub device_class: String,
 }
 
 /// General construct used by HassEntity and HassEvent


### PR DESCRIPTION
In Home Assistant there are custom attributes depending on entity.
Having them stored as Value allows user to at least access them
via `attribute[attribute_name]`.

Closes: https://github.com/danrusei/hass-rs/issues/2