### PR TITLE
avoid unwraps especially in the Error Display impl

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -266,7 +266,7 @@ impl HassClient {
         });
 
         //send command to subscribe to specific event
-        let response = self.command(cmd).await.unwrap();
+        let response = self.command(cmd).await?;
 
         //Add the callback in the event_listeners hashmap if the Subscription Response is successfull
         match response {
@@ -295,7 +295,7 @@ impl HassClient {
         });
 
         //send command to unsubscribe from specific event
-        let response = self.command(unsubscribe_req).await.unwrap();
+        let response = self.command(unsubscribe_req).await?;
 
         //Remove the event_type and the callback from the event_listeners hashmap
         match response {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,12 +60,14 @@ impl fmt::Display for HassError {
             Self::RecvError(e) => write!(f, "Receiver Error: {}", e),
             //Self::TokioTungsteniteError(e) => write!(f, "Tokio Tungstenite Error: {}", e),
             Self::UnknownPayloadReceived => write!(f, "The received payload is unknown"),
-            Self::ReponseError(e) => write!(
-                f,
-                "The error code:{} with the error message: {}",
-                e.error.as_ref().unwrap().code,
-                e.error.as_ref().unwrap().message
-            ),
+            Self::ReponseError(e) => match &e.error {
+                Some(e) => write!(
+                    f,
+                    "The error code:{} with the error message: {}",
+                    e.code, e.message
+                ),
+                None => write!(f, "ResponseError({e:?})"),
+            },
             Self::Generic(detail) => write!(f, "Generic Error: {}", detail),
         }
     }


### PR DESCRIPTION
I was unpleasantly surprised by a panic when printing an error; this commit fixes that.
