### PR TITLE
Add support for area, device and entity registries

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@
 
 use crate::types::{
     Ask, Auth, CallService, Command, HassConfig, HassEntity, HassPanels, HassServices, Response,
+    HassRegistryArea, HassRegistryDevice, HassRegistryEntity,
     Subscribe, WSEvent,
 };
 use crate::{HassError, HassResult};
@@ -280,6 +281,72 @@ impl HassClient {
                 let value = data.result()?;
                 let services: HassPanels = serde_json::from_value(value)?;
                 Ok(services)
+            }
+            unknown => Err(HassError::UnknownPayloadReceived(unknown)),
+        }
+    }
+
+    /// This will get the current area registry list from Home Assistant.
+    ///
+    /// The server will respond with a result message containing the area registry list.
+    pub async fn get_area_registry_list(&mut self) -> HassResult<Vec<HassRegistryArea>> {
+        let id = self.next_seq();
+
+        let area_req = Command::GetAreaRegistryList(Ask {
+            id,
+            msg_type: "config/area_registry/list".to_owned(),
+        });
+        let response = self.command(area_req, Some(id)).await?;
+
+        match response {
+            Response::Result(data) => {
+                let value = data.result()?;
+                let areas: Vec<HassRegistryArea> = serde_json::from_value(value)?;
+                Ok(areas)
+            }
+            unknown => Err(HassError::UnknownPayloadReceived(unknown)),
+        }
+    }
+
+    /// This will get the current device registry list from Home Assistant.
+    ///
+    /// The server will respond with a result message containing the device registry list.
+    pub async fn get_device_registry_list(&mut self) -> HassResult<Vec<HassRegistryDevice>> {
+        let id = self.next_seq();
+
+        let device_req = Command::GetDeviceRegistryList(Ask {
+            id,
+            msg_type: "config/device_registry/list".to_owned(),
+        });
+        let response = self.command(device_req, Some(id)).await?;
+
+        match response {
+            Response::Result(data) => {
+                let value = data.result()?;
+                let devices: Vec<HassRegistryDevice> = serde_json::from_value(value)?;
+                Ok(devices)
+            }
+            unknown => Err(HassError::UnknownPayloadReceived(unknown)),
+        }
+    }
+
+    /// This will get the current entity registry list from Home Assistant.
+    ///
+    /// The server will respond with a result message containing the entity registry list.
+    pub async fn get_entity_registry_list(&mut self) -> HassResult<Vec<HassRegistryEntity>> {
+        let id = self.next_seq();
+
+        let entity_req = Command::GetEntityRegistryList(Ask {
+            id,
+            msg_type: "config/entity_registry/list".to_owned(),
+        });
+        let response = self.command(entity_req, Some(id)).await?;
+
+        match response {
+            Response::Result(data) => {
+                let value = data.result()?;
+                let entities: Vec<HassRegistryEntity> = serde_json::from_value(value)?;
+                Ok(entities)
             }
             unknown => Err(HassError::UnknownPayloadReceived(unknown)),
         }

--- a/src/types/command.rs
+++ b/src/types/command.rs
@@ -15,6 +15,9 @@ pub(crate) enum Command {
     GetServices(Ask),
     GetStates(Ask),
     GetPanels(Ask),
+    GetAreaRegistryList(Ask),
+    GetDeviceRegistryList(Ask),
+    GetEntityRegistryList(Ask),
     CallService(CallService),
     #[allow(dead_code)]
     Close,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,6 +7,9 @@ mod events;
 mod panels;
 mod response;
 mod services;
+mod registry_area;
+mod registry_device;
+mod registry_entity;
 
 pub(crate) use command::*;
 pub use config::*;
@@ -15,3 +18,6 @@ pub use events::*;
 pub use panels::*;
 pub use response::*;
 pub use services::*;
+pub use registry_area::*;
+pub use registry_device::*;
+pub use registry_entity::*;

--- a/src/types/registry_area.rs
+++ b/src/types/registry_area.rs
@@ -6,7 +6,7 @@ pub struct HassRegistryArea {
     pub area_id: String,
     pub floor_id: Option<String>,
     pub humidity_entity_id: Option<String>,
-    pub icon: String,
+    pub icon: Option<String>,
     pub labels: Vec<String>,
     pub name: String,
     pub picture: Option<String>,

--- a/src/types/registry_area.rs
+++ b/src/types/registry_area.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct HassRegistryArea {
+    pub aliases: Vec<String>,
+    pub area_id: String,
+    pub floor_id: Option<String>,
+    pub humidity_entity_id: Option<String>,
+    pub icon: String,
+    pub labels: Vec<String>,
+    pub name: String,
+    pub picture: Option<String>,
+    pub temperature_entity_id: Option<String>,
+    pub created_at: f64,
+    pub modified_at: f64,
+}

--- a/src/types/registry_device.rs
+++ b/src/types/registry_device.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct HassRegistryDevice {
+    pub area_id: Option<String>,
+    pub configuration_url: Option<String>,
+    pub config_entries: Vec<String>,
+    pub config_entries_subentries: HashMap<String, Vec<Value>>,
+    pub connections: Vec<Vec<String>>,
+    pub created_at: f64,
+    pub disabled_by: Option<String>,
+    pub entry_type: Option<String>,
+    pub hw_version: Option<String>,
+    pub id: String,
+    pub identifiers: Vec<Vec<String>>,
+    pub labels: Vec<String>,
+    pub manufacturer: Option<String>,
+    pub model: Option<String>,
+    pub model_id: Option<String>,
+    pub modified_at: f64,
+    pub name_by_user: Option<String>,
+    pub name: String,
+    pub primary_config_entry: Option<String>,
+    pub serial_number: Option<String>,
+    pub sw_version: Option<String>,
+    pub via_device_id: Option<String>,
+}

--- a/src/types/registry_entity.rs
+++ b/src/types/registry_entity.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct HassRegistryEntity {
+    pub area_id: Option<String>,
+    pub categories: HashMap<String, Value>,
+    pub config_entry_id: Option<String>,
+    pub config_subentry_id: Option<String>,
+    pub created_at: f64,
+    pub device_id: Option<String>,
+    pub disabled_by: Option<String>,
+    pub entity_category: Option<String>,
+    pub entity_id: String,
+    pub has_entity_name: bool,
+    pub hidden_by: Option<String>,
+    pub icon: Option<String>,
+    pub id: String,
+    pub labels: Vec<String>,
+    pub modified_at: f64,
+    pub name: Option<String>,
+    pub options: HashMap<String, Value>,
+    pub original_name: Option<String>,
+    pub platform: String,
+    pub translation_key: Option<String>,
+    pub unique_id: String,
+}

--- a/src/types/registry_entity.rs
+++ b/src/types/registry_entity.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct HassRegistryEntity {
     pub area_id: Option<String>,
     pub categories: HashMap<String, Value>,


### PR DESCRIPTION
I tested this on my personal Home Assistant instance as well as a freshly setup one and it seems to work fine. However there might be some issues with the schemas that I didn't catch. Unfortunately there doesn't seem to be a documentation on them from Home Assistant so I had to create them based on the data that was returned to me.