### PR TITLE
fix indefinite future hang on reboot

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,8 @@
 //! Home Assistant client implementation
 
 use crate::types::{
-    Ask, Auth, CallService, Command, HassConfig, HassEntity, HassPanels, HassServices, Response,
-    HassRegistryArea, HassRegistryDevice, HassRegistryEntity,
-    Subscribe, WSEvent,
+    Ask, Auth, CallService, Command, HassConfig, HassEntity, HassPanels, HassRegistryArea,
+    HassRegistryDevice, HassRegistryEntity, HassServices, Response, Subscribe, WSEvent,
 };
 use crate::{HassError, HassResult};
 
@@ -114,6 +113,20 @@ async fn ws_incoming_messages(
                         log::error!("Error responding to ping: {err:#}");
                         break;
                     }
+                }
+                Ok(Message::Close(frame)) => {
+                    log::info!("Close message received: {:?}", frame);
+
+                    let close_reason = frame.map_or_else(String::new, |f| f.reason.into_owned());
+
+                    if let Some(tx) = rx_state.take_untagged() {
+                        tx.send(Response::Close(close_reason.clone())).ok();
+                    }
+                    let mut pending_requests = rx_state.pending_requests.lock();
+                    for (_, tx) in pending_requests.drain() {
+                        tx.send(Response::Close(close_reason.clone())).ok();
+                    }
+                    break;
                 }
                 unexpected => log::error!("Unexpected message: {unexpected:#?}"),
             },
@@ -381,6 +394,8 @@ impl HassClient {
                 data.result()?;
                 Ok(())
             }
+            // Usually happens when service triggers Home Assistant reboot, e.g. hassio.host_reboot or update.home_assistant_core_update.
+            Response::Close(_reason) => Err(HassError::ConnectionClosed),
             unknown => Err(HassError::UnknownPayloadReceived(unknown)),
         }
     }

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -23,7 +23,6 @@ pub enum Response {
     //received when subscribed to event
     Event(WSEvent),
     //when the server close the websocket connection
-    #[allow(unused)]
     Close(String),
 }
 


### PR DESCRIPTION
Reboot triggered `call_service` action,
e.g. hassio.host_reboot.

see issue #25

Note: Not sure if that fix has unintended side effects but it seems to work for me. I can catch the ConnectionClosed error now and handle it gracefully instead of the future just hanging indefinitely.