### PR TITLE
Enable native-tls feature of tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["rt", "sync"] }
-tokio-tungstenite = "0.29"
+tokio-tungstenite = { version = "0.29", features = ["native-tls"]}
 
 
 [dev-dependencies]
@@ -41,4 +41,3 @@ path = "examples/call_service.rs"
 [[example]]
 name = "subscribe_event"
 path = "examples/subscribe_event.rs"
-


### PR DESCRIPTION
Hi,

I ran into an issue running your examples because my HomeAssistant instance is only reachable via TLS. I got the following error:
```rust
TungsteniteError(Url(TlsFeatureNotEnabled))
```

This PR enables the `native-tls` feature of the tokio-tungstenite dependency, which allows your users to specify "wss://..." URLs for their secured instances. I also tried the `rustls` feature of tungstenite, but that did not fix the issue for me as I simply got the same error again.

Maybe this is helpful for others.

Best,
Florian